### PR TITLE
Support null available reward breakdown

### DIFF
--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/models/PublicUserData.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/models/PublicUserData.kt
@@ -26,7 +26,7 @@ internal data class PublicUserData(
     val wasReferred: Boolean = false,
 
     /** A list of rewards available for a user to redeem. */
-    val availableRewardBreakdown: List<AvailableRewardDetail> = emptyList()
+    val availableRewardBreakdown: List<AvailableRewardDetail>? = emptyList()
 ) {
     companion object {
         val noData = PublicUserData(

--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/models/tofu/TofuOpenData.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/models/tofu/TofuOpenData.kt
@@ -23,7 +23,7 @@ internal data class TofuOpenData(
     fun toJsonObject(): JsonObject {
         val availableRewardsBreakdown = CalculatedAvailableRewardsBreakdown.calculate(
             price,
-            publicUserData.availableRewardBreakdown
+            publicUserData.availableRewardBreakdown ?: emptyList()
         )
         return buildJsonObject {
             put(

--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/repository/RewardsRepositoryImpl.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/repository/RewardsRepositoryImpl.kt
@@ -27,7 +27,10 @@ internal class RewardsRepositoryImpl(
             merchantRepo.activeMerchant.value ?: return CalculateRewardsResult.NoRewardsSummary
 
         val calculatedAvailableRewardsBreakdown =
-            CalculatedAvailableRewardsBreakdown.calculate(price, user.availableRewardBreakdown)
+            CalculatedAvailableRewardsBreakdown.calculate(
+                price,
+                user.availableRewardBreakdown ?: emptyList()
+            )
 
         val earnedRewardsSummary = fetchEarnedRewardSummary(
             price = price,

--- a/catch-android-sdk/src/test/kotlin/com/getcatch/android/repository/TestRewardsRepositoryImpl.kt
+++ b/catch-android-sdk/src/test/kotlin/com/getcatch/android/repository/TestRewardsRepositoryImpl.kt
@@ -162,7 +162,7 @@ public class TestRewardsRepositoryImpl {
             val user = FakeDataProvider.user
             val calculatedReward = CalculatedAvailableRewardsBreakdown.calculate(
                 tenDollars,
-                user.availableRewardBreakdown
+                user.availableRewardBreakdown ?: emptyList()
             )
             rewardsRepo.fetchEarnedRewardSummary(
                 price = tenDollars,


### PR DESCRIPTION
**Description**

The api sometimes returns a null value instead of an empty list. This PR changes the data class to enable successful deserialization of the object with a null value.

**Open Questions**

**Testing**

**Relevant Links (e.g. Ticket)**

**TODOs**
