### PR TITLE
Close webview activity on errors

### DIFF
--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/ui/activities/WebViewActivity.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/ui/activities/WebViewActivity.kt
@@ -23,6 +23,7 @@ import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewState
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 
 internal abstract class WebViewActivity : ComponentActivity() {
     protected var webView: WebView? = null
@@ -40,7 +41,10 @@ internal abstract class WebViewActivity : ComponentActivity() {
 
     abstract fun handlePostMessage(message: PostMessageBody)
 
-    abstract fun handleError(error: WebViewError?)
+    open fun handleError(error: WebViewError?) {
+        Timber.e(error)
+        finish()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/ui/activities/tofu/TOFUActivity.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/ui/activities/tofu/TOFUActivity.kt
@@ -3,7 +3,6 @@ package com.getcatch.android.ui.activities.tofu
 import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.lifecycleScope
-import com.getcatch.android.exceptions.WebViewError
 import com.getcatch.android.models.EarnedRewardsSummary
 import com.getcatch.android.models.PublicKey
 import com.getcatch.android.models.tofu.MerchantDefaults
@@ -101,14 +100,6 @@ internal class TOFUActivity : WebViewActivity(), KoinComponent {
 
             else -> Timber.d("Unhandled post message: $message")
         }
-    }
-
-    override fun handleError(
-        error: WebViewError?
-    ) {
-        // Do nothing as the user can easily close TOFU if they are
-        // in a broken state and we aren't certain that the error is
-        // a sure indicator of a broken state.
     }
 
     companion object {


### PR DESCRIPTION
**Description**

Errors that the `WebViewClient` encounters indicate a failure to load the webpage. An example of this is when a user's device does not have any internet connection. Instead of failing to show the user anything and requiring them to hit the back button when it would not be obvious to do so, we will now automatically close the webview for them.

**Open Questions**

**Testing**

**Relevant Links (e.g. Ticket)**

**TODOs**
