### PR TITLE
Make initialization checks thread safe

### DIFF
--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/Catch.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/Catch.kt
@@ -64,6 +64,10 @@ public object Catch {
         publicKey: String,
         options: CatchOptions = CatchOptions(),
     ): Unit = synchronized(this) {
+        if (initialized.get()) {
+            return
+        }
+
         // Setup Timber logging
         if (options.enableLogging) {
             Timber.plant(Timber.DebugTree())
@@ -184,7 +188,7 @@ public object Catch {
         styleConfig = options.styleConfig
     }
 
-    internal fun assertInitialized() {
+    internal fun assertInitialized() = synchronized(this) {
         if (!initialized.get()) {
             throw CatchNotInitializedException()
         }


### PR DESCRIPTION
**Description**

Added a safety check to not attempt initialization twice. Also made sure the `assertInitialization` check will never have a race condition with the `initialize` function as they both need to access a lock on the `Catch` object.

**Open Questions**

**Testing**

**Relevant Links (e.g. Ticket)**

**TODOs**
