### PR TITLE
Load TOFU instantly

### DIFF
--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/ui/activities/tofu/TOFUActivity.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/ui/activities/tofu/TOFUActivity.kt
@@ -82,6 +82,10 @@ internal class TOFUActivity : WebViewActivity(), KoinComponent {
 
     override fun handlePostMessage(message: PostMessageBody) = runOnUiThread {
         when (message.action) {
+            PostMessageActions.TOFU_LISTENING -> {
+                postMessage(PostMessageBody(PostMessageActions.TOFU_LOAD))
+            }
+
             PostMessageActions.TOFU_BACK -> {
                 finish()
             }

--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/web/CatchSDKWebClient.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/web/CatchSDKWebClient.kt
@@ -1,5 +1,6 @@
 package com.getcatch.android.web
 
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.webkit.WebResourceError
@@ -20,8 +21,8 @@ internal class CatchSDKWebClient(private val webViewActivity: WebViewActivity) :
     AccompanistWebViewClient(), KoinComponent {
     private val environment: Environment by inject()
 
-    override fun onPageFinished(view: WebView?, url: String?) {
-        super.onPageFinished(view, url)
+    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+        super.onPageStarted(view, url, favicon)
         if (view != null) {
             registerPostMessageListener(view)
         }

--- a/catch-android-sdk/src/main/kotlin/com/getcatch/android/web/PostMessageActions.kt
+++ b/catch-android-sdk/src/main/kotlin/com/getcatch/android/web/PostMessageActions.kt
@@ -1,6 +1,8 @@
 package com.getcatch.android.web
 
 internal object PostMessageActions {
+    const val TOFU_LISTENING = "CATCH_TOFU_LISTENING"
+    const val TOFU_LOAD = "CATCH_TOFU_LOAD"
     const val TOFU_READY = "CATCH_TOFU_READY"
     const val TOFU_OPEN = "CATCH_TOFU_OPEN"
     const val TOFU_BACK = "CATCH_TOFU_BACK"


### PR DESCRIPTION
**Description**

A recent change was made to lazy load TOFU on web. Mobile loads TOFU lazy by default in that it opens TOFU in a webview when it is needed. So we need to tell TOFU to load immediately.

**Open Questions**

**Testing**

https://github.com/getcatch/catch-android-sdk/assets/20731645/aa66730e-198f-4573-9aba-2b76150c4106

**Relevant Links (e.g. Ticket)**

**TODOs**
